### PR TITLE
Use a single "database" configuration as connection string too

### DIFF
--- a/internal/api/resolver_mutation_configure.go
+++ b/internal/api/resolver_mutation_configure.go
@@ -127,8 +127,8 @@ func (r *mutationResolver) ConfigureGeneral(ctx context.Context, input ConfigGen
 		return nil
 	}
 
-	existingDBPath := c.GetDatabasePath()
-	if input.DatabasePath != nil && existingDBPath != *input.DatabasePath {
+	existingDBUrl := c.GetDatabaseUrl()
+	if input.DatabasePath != nil && existingDBUrl != *input.DatabasePath {
 		if err := checkConfigOverride(config.Database); err != nil {
 			return makeConfigGeneralResult(), err
 		}

--- a/internal/api/resolver_query_configuration.go
+++ b/internal/api/resolver_query_configuration.go
@@ -81,7 +81,7 @@ func makeConfigGeneralResult() *ConfigGeneralResult {
 
 	return &ConfigGeneralResult{
 		Stashes:                       config.GetStashPaths(),
-		DatabasePath:                  config.GetDatabasePath(),
+		DatabasePath:                  config.GetDatabaseUrl(),
 		BackupDirectoryPath:           config.GetBackupDirectoryPath(),
 		GeneratedPath:                 config.GetGeneratedPath(),
 		MetadataPath:                  config.GetMetadataPath(),

--- a/internal/manager/config/config.go
+++ b/internal/manager/config/config.go
@@ -50,8 +50,7 @@ const (
 
 	DefaultMaxSessionAge = 60 * 60 * 1 // 1 hours
 
-	Database                 = "database"
-	DatabaseConnectionString = "database_string"
+	Database = "database"
 
 	Exclude      = "exclude"
 	ImageExclude = "image_exclude"
@@ -692,12 +691,8 @@ func (i *Config) GetMetadataPath() string {
 	return i.getString(Metadata)
 }
 
-func (i *Config) GetDatabasePath() string {
+func (i *Config) GetDatabaseUrl() string {
 	return i.getString(Database)
-}
-
-func (i *Config) GetDatabaseConnectionString() string {
-	return i.getString(DatabaseConnectionString)
 }
 
 func (i *Config) GetBackupDirectoryPath() string {
@@ -708,7 +703,7 @@ func (i *Config) GetBackupDirectoryPathOrDefault() string {
 	ret := i.GetBackupDirectoryPath()
 	if ret == "" {
 		// #4915 - default to the same directory as the database
-		return filepath.Dir(i.GetDatabasePath())
+		return filepath.Dir(i.GetDatabaseUrl())
 	}
 
 	return ret

--- a/internal/manager/config/config_concurrency_test.go
+++ b/internal/manager/config/config_concurrency_test.go
@@ -35,7 +35,7 @@ func TestConcurrentConfigAccess(t *testing.T) {
 				i.SetInterface(Cache, i.GetCachePath())
 				i.SetInterface(Generated, i.GetGeneratedPath())
 				i.SetInterface(Metadata, i.GetMetadataPath())
-				i.SetInterface(Database, i.GetDatabasePath())
+				i.SetInterface(Database, i.GetDatabaseUrl())
 
 				// these must be set as strings since the original values are also strings
 				// setting them as []byte will cause the returned string to be corrupted


### PR DESCRIPTION
- If the `database` config option begins with `postgres:`, then we use postgres and parse it as URL
- If it begins with `sqlite:` we use SQLite (and the path to file after, e.g. `sqlite:/path/to/file.db` or `sqlite:file.db`)
- If it doesn't have any prefix, then we assume it's a SQLite DB path (e.g. `file.db`) - this is for backwards-compatibility